### PR TITLE
Fix variable reassignment error

### DIFF
--- a/lib/parse-command.js
+++ b/lib/parse-command.js
@@ -257,7 +257,15 @@ module.exports = async filePath => {
 		},
 		// Support for static props for function components, e.g. MyComponent.propTypes = ...
 		AssignmentExpression({node}) {
-			if (node.operator !== '=' || node.left.object.name !== componentName) {
+			if (node.operator !== '=') {
+				return;
+			}
+
+			if (!node.left.object || !node.left.object.name) {
+				return;
+			}
+
+			if (node.left.object.name !== componentName) {
 				return;
 			}
 

--- a/test/fixtures/parse-command/let.js
+++ b/test/fixtures/parse-command/let.js
@@ -1,0 +1,9 @@
+import PropTypes from "prop-types";
+
+/// Description
+const Demo = () => {
+	let thing;
+	thing = `value`;
+};
+
+export default Demo;

--- a/test/parse-command.js
+++ b/test/parse-command.js
@@ -248,3 +248,11 @@ test('parse class positional args', async t => {
 		]
 	});
 });
+
+test('do not error on let reassignment', async t => {
+	const command = await parseCommand(fixture('let'));
+	t.deepEqual(command, {
+		description: 'Description',
+		args: []
+	});
+});


### PR DESCRIPTION
Using variable reassignment in a component like this:

```
// in a component
let thing;
thing = "value";
```

 was resulting in the following error from `pastel dev`:

```
✖ Build failed with the following error

TypeError: Cannot read property 'name' of undefined
    at AssignmentExpression (/Users/mike/d/my-test-cli/node_modules/pasteljs/lib/parse-command.js:263:25)
    at NodePath._call (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/path/context.js:40:17)
    at NodePath.visit (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/path/context.js:88:12)
    at TraversalContext.visitQueue (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/context.js:118:16)
    at TraversalContext.visitSingle (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/context.js:90:19)
    at TraversalContext.visit (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/context.js:146:19)
    at Function.traverse.node (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/index.js:94:17)
    at NodePath.visit (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/path/context.js:95:18)
    at TraversalContext.visitQueue (/Users/mike/d/my-test-cli/node_modules/@babel/traverse/lib/context.js:118:16)
```

This should fix it!