### PR TITLE
Use pkg.bin for bin name in output

### DIFF
--- a/commands/dev.js
+++ b/commands/dev.js
@@ -23,9 +23,9 @@ module.exports = async () => {
 		process.on(event, () => unlinkBin(projectPath))
 	);
 
-	const binNamesOutput = Object.keys(pkg.bin).map(name =>
-		`${chalk.yellow('$')} ${chalk.green(name)} --help`
-	).join('\n');
+	const binNamesOutput = Object.keys(pkg.bin)
+		.map(name => `${chalk.yellow('$')} ${chalk.green(name)} --help`)
+		.join('\n');
 
 	console.log(wrapAnsi(stripIndent(`
 		${chalk.bold('Development mode')}

--- a/commands/dev.js
+++ b/commands/dev.js
@@ -23,12 +23,16 @@ module.exports = async () => {
 		process.on(event, () => unlinkBin(projectPath))
 	);
 
+	const binNamesOutput = Object.keys(pkg.bin).map(name =>
+		`${chalk.yellow('$')} ${chalk.green(name)} --help`
+	).join('\n');
+
 	console.log(wrapAnsi(stripIndent(`
 		${chalk.bold('Development mode')}
 
 		Pastel watches your "commands" directory for changes and rebuilds application when needed. After first successful build Pastel will also link your CLI for you, so feel free to run your command right away:
 
-		${chalk.yellow('$')} ${chalk.green(pkg.name)} --help
+		${binNamesOutput}
 
 		Now go create some beautiful CLI!
 	`), 80).trim() + '\n');

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -16,11 +16,13 @@ const fail = (title, description) => {
 module.exports = (projectPath, pkg) => {
 	if (!pkg.name) {
 		fail('Field "name" in package.json is empty or missing', `
-			Without "name" field it's not possible to run your CLI. Value of "name" field matches the name of command.
+			Field "name" is required to link your CLI.
+			The value of the "name" field will be used as the name of your command,
+			unless you specify another name in the "bin" field.
 
 			For example, in package.json:
 			${cardinal.highlight(`{
-			  "name": "my-awesome-cli"
+				"name": "my-awesome-cli"
 			}`)}
 
 			Then in terminal:
@@ -35,7 +37,7 @@ module.exports = (projectPath, pkg) => {
 			Field "bin" is required to create an executable command for your CLI. Add "bin" field to your package.json file like so:
 
 			${cardinal.highlight(`{
-			  "bin": "./build/cli.js"
+				"bin": "./build/cli.js"
 			}`)}
 
 			${chalk.bold('Note:')} It has to equal "./build/cli.js", because that's how Pastel is initialized.


### PR DESCRIPTION
When using `read-pkg-up` it normalizes the data so we can take advantage of this and easily provide support for multiple bin and handling scoped package names properly.

If my package is named `@linter/cli` then it's actually linked as `cli` by npm and not `@linter/cli` as the current code print by using `pkg.name`. With this change `cli` would be the name printed.

I can also update my `bin` field in `package.json` to provide multiple bins or have my bin have a different name.

```
"name: "@linter/cli",
"bin": {
  "awesome-bin-name": "./build/cli.js"
},
...
``` 