### PR TITLE
Fix unlinking on exit

### DIFF
--- a/commands/dev.js
+++ b/commands/dev.js
@@ -19,9 +19,15 @@ module.exports = async () => {
 
 	lint(projectPath, pkg);
 
-	['exit', 'SIGINT', 'SIGTERM'].forEach(event =>
-		process.on(event, () => unlinkBin(projectPath))
-	);
+	['exit', 'SIGINT', 'SIGTERM'].forEach(event => {
+		process.on(event, () => {
+			const {code} = unlinkBin(projectPath);
+
+			if (event === 'SIGINT' || event === 'SIGTERM') {
+				process.exit(code ? 1 : 0);
+			}
+		});
+	});
 
 	console.log(wrapAnsi(stripIndent(`
 		${chalk.bold('Development mode')}

--- a/lib/unlink-bin.js
+++ b/lib/unlink-bin.js
@@ -5,5 +5,5 @@ const execa = require('execa');
 module.exports = projectPath => {
 	const bin = hasYarn(projectPath) ? 'yarn' : 'npm';
 
-	return execa(bin, ['unlink']);
+	return execa.sync(bin, ['unlink']);
 };


### PR DESCRIPTION
As the same handler for unlinking is used for exit and SIGINT/SIGTERM we need to actually exit the process in case of SIGINT and SIGTERM after unlinking.

Only synchronous function calls are supported in exit handlers so use execa.sync and check exit code of that to see if we should exit with an exit code or not, based on if unlink worked.