### PR TITLE
Correctly get and set type on args

### DIFF
--- a/lib/parse-command.js
+++ b/lib/parse-command.js
@@ -47,6 +47,10 @@ const parsePropType = property => {
 			// Need to walk the whole node recursively to catch all types of `PropTypes.a.b.c` chain
 			// like `isRequired`, e.g. `PropTypes.string.isRequired`
 			walk(node.object);
+		} else if (types.isIdentifier(node)) {
+			if (propTypes.includes(node.name)) {
+				type = node.name;
+			}
 		}
 
 		// If child node of `PropTypes...` chain is a call expression, it must be a


### PR DESCRIPTION
On MacOS 10.13.3 (High Sierra), parse-command was failing to get the propType from the component and incorrectly setting the type of all args to string.

I was unable to get tests to pass, even from master without changes. I'm guessing it's because there is no lock file for dependencies and I was installing a newer version of some package that broke tests, but I'm not sure.