### PR TITLE
TypeScript support, allow missing index routes, and more

### DIFF
--- a/lib/get-entrypoint-paths.js
+++ b/lib/get-entrypoint-paths.js
@@ -6,7 +6,7 @@ const getEntrypointPaths = (commandsPath, commands) => {
 	const entrypointPaths = [];
 
 	for (const command of commands) {
-		entrypointPaths.push(path.join(commandsPath, command.path));
+		entrypointPaths.push(path.join(commandsPath, command.path || ''));
 		entrypointPaths.push(...getEntrypointPaths(commandsPath, command.subCommands));
 	}
 

--- a/lib/parse-command.js
+++ b/lib/parse-command.js
@@ -291,8 +291,9 @@ module.exports = async filePath => {
 		}
 	});
 
-	return {
+	const command = {
 		description,
+		positionalArgs: positionalArgs || [],
 		args: args.map(arg => {
 			return {
 				...arg,
@@ -302,4 +303,37 @@ module.exports = async filePath => {
 			};
 		})
 	};
+
+	const argsMap = new Map(
+		command.args.map(arg => [arg.key, arg])
+	);
+
+	if (positionalArgs && positionalArgs.length > 0) {
+		const missingArg = positionalArgs.find(key => !argsMap.has(key));
+
+		if (missingArg) {
+			throw new Error(`Positional argument \`${missingArg}\` is not declared in \`propTypes\` in \`${componentName}\``);
+		}
+
+		const firstOptionalArg = positionalArgs.findIndex(key => !argsMap.get(key).isRequired);
+
+		if (firstOptionalArg > -1 && positionalArgs.some((key, index) => index > firstOptionalArg && argsMap.get(key).isRequired)) {
+			throw new Error(`Optional positional arguments need to come after required positional arguments in \`${componentName}\``);
+		}
+
+		const variadicArg = positionalArgs.findIndex(key => argsMap.get(key).type === 'array');
+
+		if (variadicArg > -1 && variadicArg !== positionalArgs.length - 1) {
+			throw new Error(`Variadic positional argument must be at the end in \`${componentName}\``);
+		}
+
+		for (const key of positionalArgs) {
+			const {aliases} = argsMap.get(key);
+			if (aliases.length > 1) {
+				console.warn(`Positional arguments can only have up to one alias. The rest will be ignored for \`${key}\` in \`${componentName}\``);
+			}
+		}
+	}
+
+	return command;
 };

--- a/lib/read-commands.js
+++ b/lib/read-commands.js
@@ -1,12 +1,10 @@
 'use strict';
 const {promisify} = require('util');
-const {join, basename, relative} = require('path');
+const {join, relative, extname, parse} = require('path');
 const fs = require('fs');
 const parseCommand = require('./parse-command');
 
 const stat = promisify(fs.stat);
-
-const isIndexCommand = command => basename(basename(command.path, '.js'), '.tsx') === 'index';
 
 // `dirPath` is a path in source `commands` folder
 // `buildDirPath` is a path to the same folder, but in `build` folder
@@ -14,30 +12,35 @@ const readCommands = async (commandsPath, dirPath) => {
 	const paths = fs.readdirSync(dirPath);
 	const commands = [];
 
-	const promises = paths.filter(path => path.endsWith('.js') || path.endsWith('.tsx')).map(async path => {
+	const promises = paths.map(async path => {
 		// Since `readdir` returns relative paths, we need to transform them to absolute paths
 		const fullPath = join(dirPath, path);
 		const stats = await stat(fullPath);
 
 		if (stats.isDirectory()) {
 			const subCommands = await readCommands(commandsPath, fullPath);
-			const indexCommand = subCommands.find(isIndexCommand);
+			const indexCommand = subCommands.find(command => command.isIndex) || {
+				isDefaultIndex: true
+			};
 
 			commands.push({
 				...indexCommand,
+				isIndex: false,
 				name: path,
-				subCommands: subCommands.filter(command => !isIndexCommand(command))
+				subCommands: subCommands.filter(command => !command.isIndex)
 			});
 		}
 
-		if (stats.isFile()) {
-			const {description, args} = await parseCommand(fullPath);
+		if (stats.isFile() && ['.js', '.tsx'].includes(extname(fullPath))) {
+			const command = await parseCommand(fullPath);
+			const {name} = parse(fullPath);
+			const isIndex = name === 'index';
 
 			commands.push({
+				...command,
+				isIndex,
+				name: isIndex ? '*' : name,
 				path: relative(commandsPath, fullPath),
-				name: basename(basename(fullPath, '.js'), '.tsx'),
-				description,
-				args,
 				subCommands: []
 			});
 		}

--- a/readme.md
+++ b/readme.md
@@ -422,6 +422,51 @@ $ my-cli Jane Hopper
 First argument is "Jane" and second is "Hopper"
 ```
 
+The order of the fields in `positionalArgs` will be respected. Optional arguments need to appear after required ones.
+If you want to collect an arbitrary amount of arguments you can define a variadic argument by giving it the array type.
+Variadic arguments need to always be last and will capture all the remaining arguments.
+
+```jsx
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Text} from 'ink';
+
+const DownloadCommand = ({urls}) => (
+	<Text>
+		Downloading {urls.length} urls
+	</Text>
+);
+
+DownloadCommand.propTypes = {
+	urls: PropTypes.array
+};
+
+DownloadCommand.positionalArgs = ['urls'];
+
+export default DownloadCommand;
+```
+
+```bash
+$ my-cli download https://some/url https://some/other/url
+Downloading 2 urls
+```
+
+Positional arguments also support aliases, but only one per argument. The rest will be ignored.
+
+### TypeScript
+
+Pastel supports typescript by simply renaming a command file and giving it the `.tsx` extension. A `tsconfig.json` will be generated for you.
+
+If you want to define your own, make sure it contains the following:
+
+```json
+{
+	"compilerOptions": {
+		"jsx": "react"
+	}
+}
+```
+
 ### Distribution
 
 Since Pastel compiles your application, the final source code of your CLI is generated in the `build` folder.

--- a/test/fixtures/commands/aliases/commands/index.js
+++ b/test/fixtures/commands/aliases/commands/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Box, Text} from 'ink';
 
 /// Aliases command
-const Aliases = ({stream, newArg}) => (
+const Aliases = ({stream, newArg, positional}) => (
 	<Box flexDirection="column">
 		<Text>stream: {stream}</Text>
 		<Text>newArg: {newArg}</Text>
@@ -14,15 +14,20 @@ Aliases.propTypes = {
 	/// Stream arg
 	stream: PropTypes.string,
 	/// New arg
-	newArg: PropTypes.string
+	newArg: PropTypes.string,
+	/// Positional arg
+	positional: PropTypes.string
 };
 
 Aliases.shortFlags = {
 	stream: 's'
 };
 
+Aliases.positionalArgs = ['positional'];
+
 Aliases.aliases = {
-	newArg: ['oldArg']
+	newArg: ['oldArg'],
+	positional: 'otherName'
 };
 
 export default Aliases;

--- a/test/fixtures/commands/multi-command/commands/with-index/c.js
+++ b/test/fixtures/commands/multi-command/commands/with-index/c.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Text} from 'ink';
+
+const CommandC = () => <Text>Command C</Text>;
+
+export default CommandC;

--- a/test/fixtures/commands/multi-command/commands/with-index/index.js
+++ b/test/fixtures/commands/multi-command/commands/with-index/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Text} from 'ink';
+
+const CommandWithIndex = () => <Text>Command With Index</Text>;
+
+export default CommandWithIndex;

--- a/test/fixtures/commands/multi-command/commands/without-index/d.js
+++ b/test/fixtures/commands/multi-command/commands/without-index/d.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Text} from 'ink';
+
+const CommandD = () => <Text>Command D</Text>;
+
+export default CommandD;

--- a/test/fixtures/commands/positional-args/commands/index.js
+++ b/test/fixtures/commands/positional-args/commands/index.js
@@ -3,23 +3,26 @@ import PropTypes from 'prop-types';
 import {Box, Text} from 'ink';
 
 /// Positional args command
-const PositionalArgs = ({message, otherMessage, inputArgs}) => (
+const PositionalArgs = ({message, otherMessage, inputArgs, restMessages}) => (
 	<Box flexDirection="column">
 		<Text>message: {message}</Text>
 		<Text>otherMessage: {otherMessage}</Text>
+		<Text>restMessages: {JSON.stringify(restMessages)}</Text>
 		<Text>inputArgs: {JSON.stringify(inputArgs)}</Text>
 	</Box>
 );
 
 PositionalArgs.propTypes = {
+	/// Rest of the messages
+	restMessages: PropTypes.array,
 	/// Message
-	message: PropTypes.string,
+	message: PropTypes.string.isRequired,
 	/// Other message
 	otherMessage: PropTypes.string,
 	/// Input args
 	inputArgs: PropTypes.array
 };
 
-PositionalArgs.positionalArgs = ['message', 'otherMessage'];
+PositionalArgs.positionalArgs = ['message', 'otherMessage', 'restMessages'];
 
 export default PositionalArgs;

--- a/test/fixtures/commands/typescript/package.json
+++ b/test/fixtures/commands/typescript/package.json
@@ -2,6 +2,6 @@
 	"name": "test-bin",
 	"bin": "./build/cli",
 	"devDependencies": {
-		"typescript": "^3.5.2"
+		"typescript": "^3.9.7"
 	}
 }

--- a/test/fixtures/parse-command/class-positional-args.js
+++ b/test/fixtures/parse-command/class-positional-args.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 /// Description
 class Demo extends React.Component {
 	static propTypes = {
+		variadicArg: PropTypes.array,
 		arg: PropTypes.string
 	}
 
-	static positionalArgs = ['arg']
+	static positionalArgs = ['arg', 'variadicArg']
 
 	render() {
 		return null;

--- a/test/fixtures/parse-command/wrong-order-positional-args.js
+++ b/test/fixtures/parse-command/wrong-order-positional-args.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 const Demo = () => null;
 
 Demo.propTypes = {
-	optionalArg: PropTypes.string,
-	arg: PropTypes.string.isRequired
+	arg: PropTypes.string.isRequired,
+	optionalArg: PropTypes.string
 };
 
-Demo.positionalArgs = ['arg', 'optionalArg'];
+Demo.positionalArgs = ['optionalArg', 'arg'];
 
 export default Demo;

--- a/test/fixtures/parse-command/wrong-variadic-arg.js
+++ b/test/fixtures/parse-command/wrong-variadic-arg.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 const Demo = () => null;
 
 Demo.propTypes = {
-	optionalArg: PropTypes.string,
-	arg: PropTypes.string.isRequired
+	arg: PropTypes.string,
+	variadicArg: PropTypes.array
 };
 
-Demo.positionalArgs = ['arg', 'optionalArg'];
+Demo.positionalArgs = ['variadicArg', 'arg'];
 
 export default Demo;

--- a/test/parse-command.js
+++ b/test/parse-command.js
@@ -9,6 +9,7 @@ test('parse arrow function', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -28,7 +29,8 @@ test('parse arrow function with default export', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
-		args: []
+		args: [],
+		positionalArgs: []
 	});
 });
 
@@ -37,6 +39,7 @@ test('parse named function', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -56,6 +59,7 @@ test('parse named function with default export', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -75,6 +79,7 @@ test('parse class', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -94,6 +99,7 @@ test('parse class with static prop types', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -113,6 +119,7 @@ test('parse class with default export', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -132,6 +139,7 @@ test('parse prop types', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'stringArg',
@@ -178,6 +186,7 @@ test('parse function aliases and short flags', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -197,6 +206,7 @@ test('parse class aliases and short flags', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: [
 			{
 				key: 'arg',
@@ -216,12 +226,22 @@ test('parse function positional args', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: ['arg', 'optionalArg'],
 		args: [
+			{
+				key: 'optionalArg',
+				type: 'string',
+				description: '',
+				isRequired: false,
+				defaultValue: undefined,
+				aliases: [],
+				positional: true
+			},
 			{
 				key: 'arg',
 				type: 'string',
 				description: '',
-				isRequired: false,
+				isRequired: true,
 				defaultValue: undefined,
 				aliases: [],
 				positional: true
@@ -235,7 +255,17 @@ test('parse class positional args', async t => {
 
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: ['arg', 'variadicArg'],
 		args: [
+			{
+				key: 'variadicArg',
+				type: 'array',
+				description: '',
+				isRequired: false,
+				defaultValue: undefined,
+				aliases: [],
+				positional: true
+			},
 			{
 				key: 'arg',
 				type: 'string',
@@ -249,10 +279,19 @@ test('parse class positional args', async t => {
 	});
 });
 
+test('throw error when positional args are in wrong order', async t => {
+	await t.throws(parseCommand(fixture('wrong-order-positional-args')));
+});
+
+test('throw error when variadic arg is not last', async t => {
+	await t.throws(parseCommand(fixture('wrong-variadic-arg')));
+});
+
 test('do not error on let reassignment', async t => {
 	const command = await parseCommand(fixture('let'));
 	t.deepEqual(command, {
 		description: 'Description',
+		positionalArgs: [],
 		args: []
 	});
 });


### PR DESCRIPTION
Fixes #5 
Fixes #6 
Fixes #13 
Fixes #23 

Fixes part of #7 

Overall updates:

- Rework positional arguments
  - Proper display for required/optional args (`<required>` vs `[optional]`)
  - Add support for variadic args (`[variadic..]`)
  - Respect `positionalArgs` order. It used to be random (or the order the keys in `propTypes`)
  - Add some validation for `positionalArgs`
- Fix the read-commands.js logic to ignore non-js files, not mess up deeply stacked commands
- Don't require every sub-command to have an `index.js`. If not, a default message rendering the other available subcommands is shown when "index" route is called
- Fix yargs sub-command logic
  - Nesting commands with different options, would add those options to the nested commands as well, now it's properly scoped
  - If a command is not defined, it would execute silently (no error), not it shows an appropriate list of other sub-commands
  - Fix for small-edge case where if a command does not accept positional args, but there are other available sub-commands, those are suggested, as the user probably miss-typed the sub-command (used to try and call the index route)
- Better TypeScript support
  - Didn't add much other than a few fixes in `read-command.js` other than #20 
  - Couldn't reproduce https://github.com/vadimdemedes/pastel/pull/20#issuecomment-557829775
  - Automatically adds minimal `tsconfig.json` if not present and there is a `.tsx` command (like Next.js does)
- Adds tests for new functionality


Note for TypeScript, I tried looking into generating args based on types instead of propTypes but I wasn't able to find something concrete with ast, since it can get really complex with something like:

```

type FirstProps = {
   text: string
}

type OtherProps = FirstProps & {
	someOtherArg: boolean
}

type Props = OtherProps

const Home = (props: Props) => <Text>{props.text}</Text>;

export default Home
```

If there's a good way to go about it I can add in a separate PR. From some research it seems like this might be useful: https://ts-morph.com/ but I wasn't able to get far (though I didn't spend much time on this)

Thank you for Pastel, I think it's an awesome way to develop complicated Ink APIs ❤️ 
Let me know if any updates are needed 😄 
