### PR TITLE
Make react 17 an acceptable peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
 	"peerDependencies": {
 		"ink": "^2.1.1",
 		"prop-types": "^15.7.2",
-		"react": "^16.8.6"
+		"react": "^16.8.6 || ^17"
 	}
 }


### PR DESCRIPTION
Newer versions of npm will break on a version mismatch, 17 is ok to use.  #41 asks a similar question about Ink 3 but I'll defer to someone with experience.

related: https://github.com/vadimdemedes/create-pastel-app/issues/7