### PR TITLE
Allow commands directory to be inside src

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -123,7 +123,7 @@ module.exports = (dirname, React, Ink, originalCommands) => {
 	);
 
 	// NOTE: force English language
-	yargs.locale("en");
-		
+	yargs.locale('en');
+
 	yargs.parse();
 };

--- a/boot.js
+++ b/boot.js
@@ -122,5 +122,8 @@ module.exports = (dirname, React, Ink, originalCommands) => {
 		() => yargs.showHelp()
 	);
 
+	// NOTE: force English language
+	yargs.locale("en");
+		
 	yargs.parse();
 };

--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@ class Pastel extends EventEmitter {
 
 	detectCommandsPath() {
 		const paths = [
-			path.join(this.appPath, "src" ,'commands'),
-			path.join(this.appPath ,'commands')
-		]
-		
+			path.join(this.appPath, 'src', 'commands'),
+			path.join(this.appPath, 'commands')
+		];
+
 		return paths.find(path => fs.existsSync(path));
 	}
 

--- a/index.js
+++ b/index.js
@@ -19,12 +19,21 @@ class Pastel extends EventEmitter {
 		super();
 
 		this.appPath = appPath;
-		this.commandsPath = path.join(appPath, 'commands');
+		this.commandsPath = this.detectCommandsPath();
 		this.buildPath = path.join(appPath, 'build');
 		this.cachePath = path.join(appPath, 'node_modules', '.cache', 'parcel');
 		this.tsConfigPath = path.join(appPath, 'tsconfig.json');
 
 		this.testMode = testMode;
+	}
+
+	detectCommandsPath() {
+		const paths = [
+			path.join(this.appPath, "src" ,'commands'),
+			path.join(this.appPath ,'commands')
+		]
+		
+		return paths.find(path => fs.existsSync(path));
 	}
 
 	checkOrCreateTsConfig() {

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -8,7 +8,7 @@ const figures = require('figures');
 const chalk = require('chalk');
 
 const fail = (title, description) => {
-	const wrappedDescription = wrapAnsi(stripIndent(description).trim(), 80, {trim: false});
+	const wrappedDescription = wrapAnsi(stripIndent(description).trim(), 80, { trim: false });
 	console.log(`${chalk.red(figures.cross)} ${title}\n\n${wrappedDescription}`);
 	process.exit(1); // eslint-disable-line unicorn/no-process-exit
 };
@@ -43,10 +43,13 @@ module.exports = (projectPath, pkg) => {
 			${chalk.dim('Learn more at https://docs.npmjs.com/files/package.json#bin')}
 		`);
 	}
+	const commandsPath = fs.existsSync(path.join(projectPath, 'src', 'commands')) 
+		? path.join(projectPath, 'src', 'commands') 
+		: path.join(projectPath, 'commands');
 
-	if (!fs.existsSync(path.join(projectPath, 'commands'))) {
+	if (!fs.existsSync(commandsPath)) {
 		fail('Directory "commands" is missing', `
-			Pastel requires "commands" directory to exist in the root of your application, because that's where it looks for your commands.
+			Pastel requires "commands" directory to exist in the root of your application or in src directory, because that's where it looks for your commands.
 
 			Create a "commands" directory like this:
 
@@ -54,10 +57,11 @@ module.exports = (projectPath, pkg) => {
 		`);
 	}
 
-	const commands = fs.readdirSync(path.join(projectPath, 'commands'));
+	const commands = fs.readdirSync(commandsPath);
+
 	if (commands.length === 0) {
 		fail('Commands were not found', `
-			Pastel requires at least one command to exist in "commands" directory. Create an "index.js" file in "commands" directory and paste this example code:
+			Pastel requires at least one command to exist in "commands" directory or in src directory. Create an "index.js" file in "commands" directory and paste this example code:
 
 			${cardinal.highlight(`
 			import React from 'react';
@@ -66,7 +70,7 @@ module.exports = (projectPath, pkg) => {
 			const HelloWorld = () => <Text>Hello World</Text>;
 
 			export default HelloWorld;
-			`.trim(), {jsx: true})}
+			`.trim(), { jsx: true })}
 
 			After you've done that, run this command again.
 		`);

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -8,7 +8,7 @@ const figures = require('figures');
 const chalk = require('chalk');
 
 const fail = (title, description) => {
-	const wrappedDescription = wrapAnsi(stripIndent(description).trim(), 80, { trim: false });
+	const wrappedDescription = wrapAnsi(stripIndent(description).trim(), 80, {trim: false});
 	console.log(`${chalk.red(figures.cross)} ${title}\n\n${wrappedDescription}`);
 	process.exit(1); // eslint-disable-line unicorn/no-process-exit
 };
@@ -43,9 +43,9 @@ module.exports = (projectPath, pkg) => {
 			${chalk.dim('Learn more at https://docs.npmjs.com/files/package.json#bin')}
 		`);
 	}
-	const commandsPath = fs.existsSync(path.join(projectPath, 'src', 'commands')) 
-		? path.join(projectPath, 'src', 'commands') 
-		: path.join(projectPath, 'commands');
+	const commandsPath = fs.existsSync(path.join(projectPath, 'src', 'commands')) ?
+		path.join(projectPath, 'src', 'commands') :
+		path.join(projectPath, 'commands');
 
 	if (!fs.existsSync(commandsPath)) {
 		fail('Directory "commands" is missing', `
@@ -70,7 +70,7 @@ module.exports = (projectPath, pkg) => {
 			const HelloWorld = () => <Text>Hello World</Text>;
 
 			export default HelloWorld;
-			`.trim(), { jsx: true })}
+			`.trim(), {jsx: true})}
 
 			After you've done that, run this command again.
 		`);

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,11 @@ $ npm install pastel ink react prop-types
 Then create a `commands` folder:
 
 ```bash
+# if we need commands in root directory
 $ mkdir commands
+
+# or if we want commands in src directoyr
+$ mkdir -p src/commands
 ```
 
 Then you can start creating commands in that folder. Let's create a main command, which has to be named `index.js` at `commands/index.js`:

--- a/test/commands.js
+++ b/test/commands.js
@@ -18,7 +18,7 @@ const build = async fixture => {
 
 const cli = async (fixture, args = [], {returnStderr} = {}) => {
 	const {stdout, stderr} = await execa('node', [path.join(__dirname, 'fixtures', 'commands', fixture, 'build', 'cli'), ...args], {
-		cwd: path.join(__dirname, 'fixtures', 'commands', fixture)
+		cwd: path.join(__dirname, 'fixtures', 'commands', fixture),
 	});
 
 	return returnStderr ? stderr : stdout;
@@ -189,6 +189,13 @@ test('positional args', async t => {
 test('typescript', async t => {
 	await build('typescript');
 	const output = await cli('typescript');
+
+	t.is(output, 'Hello world');
+});
+
+test('command in src dir', async t => {
+	await build('command-in-src-dir');
+	const output = await cli('command-in-src-dir');
 
 	t.is(output, 'Hello world');
 });

--- a/test/commands.js
+++ b/test/commands.js
@@ -18,7 +18,7 @@ const build = async fixture => {
 
 const cli = async (fixture, args = [], {returnStderr} = {}) => {
 	const {stdout, stderr} = await execa('node', [path.join(__dirname, 'fixtures', 'commands', fixture, 'build', 'cli'), ...args], {
-		cwd: path.join(__dirname, 'fixtures', 'commands', fixture),
+		cwd: path.join(__dirname, 'fixtures', 'commands', fixture)
 	});
 
 	return returnStderr ? stderr : stdout;

--- a/test/fixtures/commands/command-in-src-dir/package.json
+++ b/test/fixtures/commands/command-in-src-dir/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "test-bin",
+	"bin": "./build/cli"
+}

--- a/test/fixtures/commands/command-in-src-dir/src/commands/index.js
+++ b/test/fixtures/commands/command-in-src-dir/src/commands/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import {Text} from 'ink';
+
+const Hello = () => <Text>Hello world</Text>;
+
+export default Hello;

--- a/test/fixtures/commands/typescript/package.json
+++ b/test/fixtures/commands/typescript/package.json
@@ -2,6 +2,6 @@
 	"name": "test-bin",
 	"bin": "./build/cli",
 	"devDependencies": {
-		"typescript": "^3.9.7"
+		"typescript": "^4.7.3"
 	}
 }


### PR DESCRIPTION
Pastel is a great tool to write CLI with React on board. Currently, only the top-level "commands" directory is allowed, so I also want to introduce the commands directory inside the src directory that will be used instead of the top-level one.
This works similar to how nextjs place its own "pages" directory.