### PR TITLE
Fix typos in readme code examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1088,7 +1088,7 @@ Parses the arguments and runs the app.
 
 ##### argv
 
-Type: `Array`
+Type: `Array`\
 Default: `process.argv`
 
 Program arguments.
@@ -1135,7 +1135,7 @@ Type: `object`
 
 ##### name
 
-Type: `string`
+Type: `string`\
 Default: `'arg'`
 
 Argument's name. Displayed in "Usage" part of the help message. Doesn't affect how argument is parsed.

--- a/readme.md
+++ b/readme.md
@@ -680,7 +680,7 @@ export const options = zod.object({
 		.number()
 		.default(1024)
 		.describe(
-			pastel({
+			option({
 				description: 'Memory size',
 				defaultValueDescription: '1 GB',
 			}),
@@ -758,7 +758,7 @@ import zod from 'zod';
 export const args = zod.tuple([zod.string(), zod.string()]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Move({args}: Props) {
@@ -787,7 +787,7 @@ import zod from 'zod';
 export const args = zod.array(zod.string());
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Remove({args}: Props) {
@@ -824,7 +824,7 @@ export const args = zod.tuple([
 ]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Hello({args}: Props) {
@@ -857,7 +857,7 @@ export const args = zod.tuple([
 ]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Hello({args}: Props) {
@@ -890,7 +890,7 @@ export const args = zod.tuple([
 ]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Example({args}: Props) {
@@ -926,7 +926,7 @@ export const args = zod.tuple([
 ]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Example({args}: Props) {
@@ -971,7 +971,7 @@ export const args = zod.tuple([
 ]);
 
 type Props = {
-	args: zod.infer<typeof arguments>;
+	args: zod.infer<typeof args>;
 };
 
 export default function Example({args}: Props) {
@@ -1088,7 +1088,7 @@ Parses the arguments and runs the app.
 
 ##### argv
 
-Type: `Array`\
+Type: `Array`
 Default: `process.argv`
 
 Program arguments.
@@ -1135,7 +1135,7 @@ Type: `object`
 
 ##### name
 
-Type: `string`\
+Type: `string`
 Default: `'arg'`
 
 Argument's name. Displayed in "Usage" part of the help message. Doesn't affect how argument is parsed.


### PR DESCRIPTION
Seen some logical typos while reading readme, so decided to fix them 🫡