### PR TITLE
Resolve "ERR_UNSUPPORTED_ESM_URL_SCHEME" Error in Windows

### DIFF
--- a/source/read-custom-app.ts
+++ b/source/read-custom-app.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import {pathToFileURL} from 'node:url';
 import {type ComponentType} from 'react';
 import {type AppProps} from './types.js';
 
@@ -19,7 +20,7 @@ export default async function readCustomApp(
 		}
 
 		const filePath = path.join(directory, file);
-		const m = (await import(filePath)) as AppExports;
+		const m = (await import(pathToFileURL(filePath).href)) as AppExports;
 
 		customApp = m.default;
 		break;


### PR DESCRIPTION
When using the library on Windows the `ERR_UNSUPPORTED_ESM_URL_SCHEME ` occurs. I discovered that it's related to the path used in `read-custom-app.ts` file. Using `pathToFileURL` should solve the issue by transforming path to absolute value.

Related issues: 
- https://github.com/brainhubeu/license-auditor/issues/162
- https://github.com/vadimdemedes/pastel/issues/55
