### PR TITLE
New ignore config option to allow files or folders to be ignored for command discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
 		"commander": "^14.0.1",
 		"decamelize": "^6.0.1",
 		"plur": "^5.1.0",
+		"picomatch": "^4.0.3",
 		"read-package-up": "^11.0.0",
 		"zod-validation-error": "^4.0.2"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^8.0.1",
+		"@types/picomatch":"^4.0.2",
 		"@types/react": "^19.2.2",
 		"@types/yargs": "^17.0.33",
 		"@vdemedes/prettier-config": "^2.0.1",

--- a/readme.md
+++ b/readme.md
@@ -1081,6 +1081,41 @@ Type: [`ImportMeta`](https://nodejs.org/dist/latest/docs/api/esm.html#esm_import
 
 Pass in [`import.meta`](https://nodejs.org/dist/latest/docs/api/esm.html#esm_import_meta). This is used to find the `commands` directory.
 
+##### ignore
+
+Type: `string[]`
+
+Glob patterns for files and folders to ignore during command discovery. Patterns are matched against paths relative to the `commands` directory.
+
+###### Examples
+
+Ignore top-level files and folders named `__tests__` only:
+
+```ts
+const app = new Pastel({
+	...,
+	ignore: ['__tests__'],
+});
+```
+
+Ignore nested `__tests__/` folders at any depth:
+
+```ts
+const app = new Pastel({
+	...,
+	ignore: ['**/__tests__/'],
+});
+```
+
+Ignore certain files, even in nested folders:
+
+```ts
+const app = new Pastel({
+	...,
+	ignore: ['**/*.test.tsx'],
+});
+```
+
 #### run(argv)
 
 Parses the arguments and runs the app.

--- a/source/index.ts
+++ b/source/index.ts
@@ -29,6 +29,13 @@ export type Options = {
 	 * Pass in [`import.meta`](https://nodejs.org/dist/latest/docs/api/esm.html#esm_import_meta). This is used to find the `commands` directory.
 	 */
 	importMeta: ImportMeta;
+
+	/**
+	 * Glob patterns for files and folders to ignore during command discovery.
+	 *
+	 * Patterns are matched against paths relative to the `commands` directory.
+	 */
+	ignore?: string[];
 };
 
 export default class Pastel {
@@ -49,7 +56,9 @@ export default class Pastel {
 		const appComponent = (await readCustomApp(commandsDirectory)) ?? App;
 		const program = new Command();
 
-		const commands = await readCommands(commandsDirectory);
+		const commands = await readCommands(commandsDirectory, {
+			ignore: this.options.ignore,
+		});
 		const indexCommand = commands.get('index');
 
 		if (indexCommand) {

--- a/source/read-commands.ts
+++ b/source/read-commands.ts
@@ -2,13 +2,33 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import decamelize from 'decamelize';
+import picomatch from 'picomatch';
 import type {CommandExports, Command} from './internal-types.js';
+
+type ReadCommandsOptions = {
+	ignore?: string[];
+	rootDirectory?: string;
+	isIgnoredPath?: (filePath: string) => boolean;
+};
 
 const readCommands = async (
 	directory: string,
+	options: ReadCommandsOptions = {},
 ): Promise<Map<string, Command>> => {
 	const commands = new Map<string, Command>();
 	const files = await fs.readdir(directory);
+	const rootDirectory = options.rootDirectory ?? directory;
+	const ignore = options.ignore ?? [];
+	// remove trailing slash from glob patterns
+	const normalizedIgnore = ignore.map(
+		pattern => pattern.replace(/\/+$/g, '') || pattern,
+	);
+	const isIgnoredPath =
+		options.isIgnoredPath ??
+		picomatch(normalizedIgnore, {
+			dot: true,
+			posixSlashes: true,
+		});
 
 	for (const file of files) {
 		if (file.startsWith('_app')) {
@@ -16,10 +36,19 @@ const readCommands = async (
 		}
 
 		const filePath = path.join(directory, file);
+		const relativePath = path.relative(rootDirectory, filePath);
+
+		if (isIgnoredPath(relativePath)) {
+			continue;
+		}
+
 		const stat = await fs.stat(filePath);
 
 		if (stat.isDirectory()) {
-			const subCommands = await readCommands(filePath);
+			const subCommands = await readCommands(filePath, {
+				rootDirectory,
+				isIgnoredPath,
+			});
 			const indexCommand = subCommands.get('index');
 
 			if (indexCommand) {

--- a/test/commands.ts
+++ b/test/commands.ts
@@ -595,3 +595,55 @@ test('command with an alias', async t => {
 		].join('\n'),
 	);
 });
+
+test('ignore patterns in command discovery', async t => {
+	const fixture = 'ignored-commands';
+
+	const indexHelp = await run(fixture, ['--help']);
+
+	t.is(
+		indexHelp.stdout,
+		[
+			'Usage: test [options] [command]',
+			'',
+			'Description',
+			'',
+			'Options:',
+			'  -v, --version   Show version number',
+			'  -h, --help      Show help',
+			'',
+			'Commands:',
+			'  auth            Auth command',
+			'  servers         Manage servers',
+			'  help [command]  Show help for command',
+		].join('\n'),
+	);
+
+	const servers = await run(fixture, ['servers'], {
+		reject: false,
+	});
+
+	t.is(
+		servers.stderr,
+		[
+			'Usage: test servers [options] [command]',
+			'',
+			'Manage servers',
+			'',
+			'Options:',
+			'  -h, --help      Show help',
+			'',
+			'Commands:',
+			'  list            List servers',
+			'  help [command]  Show help for command',
+		].join('\n'),
+	);
+
+	const ignoredNestedCommand = await run(fixture, ['servers', '__tests__'], {
+		reject: false,
+	});
+
+	t.true(
+		String(ignoredNestedCommand.stderr).includes("unknown command '__tests__'"),
+	);
+});

--- a/test/fixtures/ignored-commands/cli.ts
+++ b/test/fixtures/ignored-commands/cli.ts
@@ -1,0 +1,11 @@
+import Pastel from '../../../source/index.js';
+
+const app = new Pastel({
+	name: 'test',
+	version: '0.0.0',
+	description: 'Description',
+	importMeta: import.meta,
+	ignore: ['__tests__', '**/__tests__', '.dotfolder/'],
+});
+
+await app.run();

--- a/test/fixtures/ignored-commands/commands/.dotfolder/test.tsx
+++ b/test/fixtures/ignored-commands/commands/.dotfolder/test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Text} from 'ink';
+
+export const description = 'Test command';
+
+export default function TestCommand() {
+	return <Text>Test</Text>;
+}

--- a/test/fixtures/ignored-commands/commands/__tests__/index.tsx
+++ b/test/fixtures/ignored-commands/commands/__tests__/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Text} from 'ink';
+
+export const description = 'Ignored test command';
+
+export default function RootTests() {
+	return <Text>Root tests command</Text>;
+}

--- a/test/fixtures/ignored-commands/commands/auth.tsx
+++ b/test/fixtures/ignored-commands/commands/auth.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {Text} from 'ink';
+
+export const description = 'Auth command';
+export const isDefault = true;
+
+export default function Auth() {
+	return <Text>Auth</Text>;
+}

--- a/test/fixtures/ignored-commands/commands/servers/__tests__/index.tsx
+++ b/test/fixtures/ignored-commands/commands/servers/__tests__/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Text} from 'ink';
+
+export const description = 'Ignored nested test command';
+
+export default function NestedTests() {
+	return <Text>Nested tests command</Text>;
+}

--- a/test/fixtures/ignored-commands/commands/servers/index.ts
+++ b/test/fixtures/ignored-commands/commands/servers/index.ts
@@ -1,0 +1,1 @@
+export const description = 'Manage servers';

--- a/test/fixtures/ignored-commands/commands/servers/list.tsx
+++ b/test/fixtures/ignored-commands/commands/servers/list.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Text} from 'ink';
+
+export const description = 'List servers';
+
+export default function ListServers() {
+	return <Text>List servers</Text>;
+}


### PR DESCRIPTION
I run into the problem that in my project i do colocate the tests in __tests__ folders and these are also picked up as commands.

This PR adds a new config option `ignore` that allows to set glob patterns that are used to ignore certain files to be picked up as commands.

Let me know what you think?

Fixes #83 